### PR TITLE
fix: update default branch

### DIFF
--- a/internal-functions
+++ b/internal-functions
@@ -31,7 +31,7 @@ fn-update-discourse-build-files() {
   if [[ -d "$DISCOURSE_DOCKER_IMAGE_ROOT" ]]; then
     cd "$DISCOURSE_DOCKER_IMAGE_ROOT"
     dokku_log_info1 "Updating the discourse image build files"
-    git pull origin master
+    git pull origin main
   else
     dokku_log_info1 "Cloning the discourse image build files"
     git clone https://github.com/discourse/discourse_docker.git "$DISCOURSE_DOCKER_IMAGE_ROOT"

--- a/internal-functions
+++ b/internal-functions
@@ -192,7 +192,7 @@ fn-configure-app() {
 
   local RUN_ARGS MAC_ADDRESS SHM_SIZE ENV_VARS
 
-  RUN_ARGS=$(fn-get-run-args "$APP_NAME" 2>&1)
+  RUN_ARGS=$(fn-get-run-args "$APP_NAME" 2>&1 >/dev/null)
   MAC_ADDRESS=$(echo "$RUN_ARGS" | sed -r 's/.*--mac-address(=| )([^ ]+).*/\2/')
   SHM_SIZE=$(echo "$RUN_ARGS" | sed -r 's/.*--shm-size(=| )([^ ]+).*/\2/')
   ENV_VARS=$(fn-get-env-vars-from-run-args "$RUN_ARGS")


### PR DESCRIPTION
Discourse now uses main as the default branch. Switching from master to main allows updating discourse to newer versions

Newer versions may require fixing permissions on redis' files